### PR TITLE
Fix changeset deletion racing with creation

### DIFF
--- a/code/handler.py
+++ b/code/handler.py
@@ -1,22 +1,24 @@
 import json
 import boto3
+import datetime
 from botocore.config import Config
 
 
 def lambda_handler(event, context):
     dry_run = get_dry_run_parameter(event)
     regions = get_regions_parameter(event)
+    delete_only_if_created_before = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=-3)
 
     for region in regions:
         print('REGION: {}'.format(region))
         config = Config(retries={'max_attempts': 50, 'mode': 'standard'})
         cfn_client = boto3.client('cloudformation', region_name=region, config=config)
 
-        failed_change_sets = find_failed_change_sets(cfn_client)
+        failed_change_sets = find_failed_change_sets(cfn_client, delete_only_if_created_before)
         delete_change_sets(failed_change_sets, cfn_client, region, dry_run)
 
 
-def find_failed_change_sets(cfn_client):
+def find_failed_change_sets(cfn_client, delete_only_if_created_before):
     failed_change_sets = []
 
     stacks_paginator = cfn_client.get_paginator('list_stacks')
@@ -24,18 +26,18 @@ def find_failed_change_sets(cfn_client):
             StackStatusFilter=['CREATE_FAILED', 'CREATE_COMPLETE', 'ROLLBACK_FAILED', 'ROLLBACK_COMPLETE', 'DELETE_FAILED', 'UPDATE_COMPLETE', 'UPDATE_FAILED', 'UPDATE_ROLLBACK_FAILED', 'UPDATE_ROLLBACK_COMPLETE', 'IMPORT_COMPLETE', 'IMPORT_ROLLBACK_FAILED', 'IMPORT_ROLLBACK_COMPLETE']):
         for stack in stacks_response.get('StackSummaries'):
             stack_name = stack['StackName']
-            failed_change_sets.extend(check_stack(stack_name, cfn_client))
+            failed_change_sets.extend(check_stack(stack_name, cfn_client, delete_only_if_created_before))
 
     return failed_change_sets
 
 
-def check_stack(stack_name, cfn_client):
+def check_stack(stack_name, cfn_client, delete_only_if_created_before):
     failed_change_sets = []
 
     paginator = cfn_client.get_paginator('list_change_sets')
     for response in paginator.paginate(StackName=stack_name):
         for change_set in response.get('Summaries'):
-            if change_set['Status'] == "FAILED":
+            if change_set['Status'] == "FAILED" and change_set["CreationTime"] < delete_only_if_created_before:
                 change_set_result = ChangeSet(change_set['StackName'], change_set['ChangeSetName'])
                 failed_change_sets.append(change_set_result)
 


### PR DESCRIPTION
Resolves #2

This also leaves some room for developers to read fails reasons when not due to empty changeset.