### PR TITLE
Stream-process stacks

### DIFF
--- a/code/handler.py
+++ b/code/handler.py
@@ -1,22 +1,24 @@
 import json
 import boto3
+import datetime
 from botocore.config import Config
 
 
 def lambda_handler(event, context):
     dry_run = get_dry_run_parameter(event)
     regions = get_regions_parameter(event)
+    delete_only_if_created_before = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=-3)
 
     for region in regions:
         print('REGION: {}'.format(region))
         config = Config(retries={'max_attempts': 50, 'mode': 'standard'})
         cfn_client = boto3.client('cloudformation', region_name=region, config=config)
 
-        failed_change_sets = find_failed_change_sets(cfn_client)
+        failed_change_sets = find_failed_change_sets(cfn_client, delete_only_if_created_before)
         delete_change_sets(failed_change_sets, cfn_client, region, dry_run)
 
 
-def find_failed_change_sets(cfn_client):
+def find_failed_change_sets(cfn_client, delete_only_if_created_before):
     failed_change_sets = []
 
     stacks_paginator = cfn_client.get_paginator('list_stacks')
@@ -24,18 +26,18 @@ def find_failed_change_sets(cfn_client):
             StackStatusFilter=['CREATE_FAILED', 'CREATE_COMPLETE', 'ROLLBACK_FAILED', 'ROLLBACK_COMPLETE', 'DELETE_FAILED', 'UPDATE_COMPLETE', 'UPDATE_FAILED', 'UPDATE_ROLLBACK_FAILED', 'UPDATE_ROLLBACK_COMPLETE', 'IMPORT_COMPLETE', 'IMPORT_ROLLBACK_FAILED', 'IMPORT_ROLLBACK_COMPLETE']):
         for stack in stacks_response.get('StackSummaries'):
             stack_name = stack['StackName']
-            failed_change_sets.extend(check_stack(stack_name, cfn_client))
+            failed_change_sets.extend(check_stack(stack_name, cfn_client, delete_only_if_created_before))
 
     return failed_change_sets
 
 
-def check_stack(stack_name, cfn_client):
+def check_stack(stack_name, cfn_client, delete_only_if_created_before):
     failed_change_sets = []
 
     paginator = cfn_client.get_paginator('list_change_sets')
     for response in paginator.paginate(StackName=stack_name):
         for change_set in response.get('Summaries'):
-            if change_set['Status'] == "FAILED":
+            if change_set['Status'] == "FAILED" and change_set["CreationTime"] < delete_only_if_created_before:
                 change_set_result = ChangeSet(change_set['StackName'], change_set['ChangeSetName'])
                 failed_change_sets.append(change_set_result)
 

--- a/code/handler.py
+++ b/code/handler.py
@@ -14,43 +14,37 @@ def lambda_handler(event, context):
         config = Config(retries={'max_attempts': 50, 'mode': 'standard'})
         cfn_client = boto3.client('cloudformation', region_name=region, config=config)
 
-        failed_change_sets = find_failed_change_sets(cfn_client, delete_only_if_created_before)
-        delete_change_sets(failed_change_sets, cfn_client, region, dry_run)
+        n_failed_change_sets = delete_failed_change_sets(cfn_client, delete_only_if_created_before, dry_run)
+        print('There were {} failed change sets in {}.'.format(n_failed_change_sets, region))
 
 
-def find_failed_change_sets(cfn_client, delete_only_if_created_before):
-    failed_change_sets = []
+def delete_failed_change_sets(cfn_client, delete_only_if_created_before, dry_run):
+    n_failed_changesets = 0
 
     stacks_paginator = cfn_client.get_paginator('list_stacks')
     for stacks_response in stacks_paginator.paginate(
             StackStatusFilter=['CREATE_FAILED', 'CREATE_COMPLETE', 'ROLLBACK_FAILED', 'ROLLBACK_COMPLETE', 'DELETE_FAILED', 'UPDATE_COMPLETE', 'UPDATE_FAILED', 'UPDATE_ROLLBACK_FAILED', 'UPDATE_ROLLBACK_COMPLETE', 'IMPORT_COMPLETE', 'IMPORT_ROLLBACK_FAILED', 'IMPORT_ROLLBACK_COMPLETE']):
         for stack in stacks_response.get('StackSummaries'):
             stack_name = stack['StackName']
-            failed_change_sets.extend(check_stack(stack_name, cfn_client, delete_only_if_created_before))
+            n_failed_changesets += check_stack(stack_name, cfn_client, delete_only_if_created_before, dry_run)
 
-    return failed_change_sets
+    return n_failed_changesets
 
 
-def check_stack(stack_name, cfn_client, delete_only_if_created_before):
-    failed_change_sets = []
+def check_stack(stack_name, cfn_client, delete_only_if_created_before, dry_run):
+    n_failed_changesets = 0
 
     paginator = cfn_client.get_paginator('list_change_sets')
     for response in paginator.paginate(StackName=stack_name):
         for change_set in response.get('Summaries'):
             if change_set['Status'] == "FAILED" and change_set["CreationTime"] < delete_only_if_created_before:
-                change_set_result = ChangeSet(change_set['StackName'], change_set['ChangeSetName'])
-                failed_change_sets.append(change_set_result)
+                failed_change_set = ChangeSet(change_set['StackName'], change_set['ChangeSetName'])
+                print('Removing changeset: {}'.format(json.dumps(failed_change_set, default=lambda x: x.__dict__)))
+                n_failed_changesets += 1
+                if not dry_run:
+                    cfn_client.delete_change_set(StackName=failed_change_set.stack_name, ChangeSetName=failed_change_set.name)
 
-    return failed_change_sets
-
-
-def delete_change_sets(failed_change_sets, cfn_client, region, dry_run):
-    print('Stacks with failed change sets to remove:\n{}'.format(json.dumps(failed_change_sets, default=lambda x: x.__dict__)))
-    print('There were {} failed change sets in {}.'.format(len(failed_change_sets), region))
-    if not dry_run:
-        for change_set in failed_change_sets:
-            cfn_client.delete_change_set(StackName=change_set.stack_name, ChangeSetName=change_set.name)
-
+    return n_failed_changesets
 
 def get_dry_run_parameter(event):
     if 'dry_run' not in event:


### PR DESCRIPTION
This builds on top of #3 (otherwise would conflict)

This processes the deletions in a streaming fashion instead of pre-loading everything.
This allows starting to delete before everything is loaded, resulting in processing more deletions if there's not enough time in the allocated 900 seconds to process everything.

Ideally we'd preload all the stacks names then use multiprocessing to make several requests at the same time to AWS to delete them, but that will be for another time. (https://stackoverflow.com/questions/48091874/downloading-multiple-s3-objects-in-parallel-in-python)